### PR TITLE
Restore original status-left on toggle off

### DIFF
--- a/scripts/toggle_off.sh
+++ b/scripts/toggle_off.sh
@@ -2,5 +2,9 @@
 
 tmux set -u prefix
 tmux set -u key-table
-tmux set -g status-left ""
+
+# Restore the original status-left saved by toggle_on
+saved="$(tmux show-option -gv @remote-saved-status-left 2>/dev/null)"
+tmux set -g status-left "$saved"
+
 tmux refresh-client -S

--- a/scripts/toggle_on.sh
+++ b/scripts/toggle_on.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Save the current status-left so toggle_off can restore it
+tmux set -g @remote-saved-status-left "$(tmux show-option -gv status-left)"
+
 tmux set prefix None
 tmux set key-table off
 tmux set -g status-left "#[fg=colour228,bg=colour52] REMOTE >>>  #[bg=default] "


### PR DESCRIPTION
## Summary
- Fixes #1. `toggle_off.sh` previously reset `status-left` to an empty string, permanently wiping any theme customization (e.g. tmux-nord session numbers)
- `toggle_on.sh` now saves the current `status-left` to `@remote-saved-status-left` before overwriting
- `toggle_off.sh` restores from that saved value instead of resetting to `""`

## Test plan
- [ ] Set a custom `status-left` (or use a theme like tmux-nord)
- [ ] Toggle remote mode on with F12 — verify "REMOTE >>>" appears
- [ ] Toggle remote mode off with F12 — verify original status-left is restored