### PR TITLE
Fix shell quoting bugs and clean up stale artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-run_tests
-tests/run_tests_in_isolation
-tests/helpers/helpers.sh

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![](https://i.imgur.com/3gfFGpk.png)
 
-Tested and working macOS and Linux.
+Tested and working on macOS and Linux. Requires tmux 2.1+.
 
 ## Installation
 
@@ -49,19 +49,15 @@ After installing the plugin, simply press <kbd>F12</kbd> to toggle remote-mode o
 
 ```tmux
 # Change the default on keybinding (F10)
-setw -g @remote-on-key F10
+set -g @remote-on-key F10
 # Change the default off keybinding (F11)
-setw -g @remote-off-key F11
+set -g @remote-off-key F11
 # Change the default toggle keybinding (F12)
-setw -g @remote-toggle-key F12
+set -g @remote-toggle-key F12
 ```
 
 ## Testing
-Basic tests have been created with [tmux-test](https://github.com/tmux-plugins/tmux-test). To run tests:
-
-```
-> ./run_tests
-```
+Tests run automatically via [GitHub Actions](https://github.com/danyim/tmux-remote/actions/workflows/test.yml) on push and PR.
 
 ## Resources
 

--- a/remote.tmux
+++ b/remote.tmux
@@ -6,42 +6,42 @@ source "$CURRENT_DIR/scripts/variables.sh"
 source "$CURRENT_DIR/scripts/helpers.sh"
 
 main() {
-	if option_not_set $toggle_key_option; then
-		tmux set-option -g $toggle_key_option $default_toggle_key
+	if option_not_set "$toggle_key_option"; then
+		tmux set-option -g "$toggle_key_option" "$default_toggle_key"
 	fi
-	if option_not_set $on_key_option; then
-		tmux set-option -g $on_key_option $default_on_key
+	if option_not_set "$on_key_option"; then
+		tmux set-option -g "$on_key_option" "$default_on_key"
 	fi
-	if option_not_set $off_key_option; then
-		tmux set-option -g $off_key_option $default_off_key
+	if option_not_set "$off_key_option"; then
+		tmux set-option -g "$off_key_option" "$default_off_key"
 	fi
 
 	local toggle_key=$(tmux show-option -gv "$toggle_key_option")
 	local on_key=$(tmux show-option -gv "$on_key_option")
 	local off_key=$(tmux show-option -gv "$off_key_option")
 
-	tmux unbind -T root $toggle_key
-	tmux unbind -T off $toggle_key
-	tmux unbind -T root $on_key
-	tmux unbind -T off $on_key
-	tmux unbind -T root $off_key
-	tmux unbind -T off $off_key
+	tmux unbind -T root "$toggle_key"
+	tmux unbind -T off "$toggle_key"
+	tmux unbind -T root "$on_key"
+	tmux unbind -T off "$on_key"
+	tmux unbind -T root "$off_key"
+	tmux unbind -T off "$off_key"
 
 	# Press the toggle key to toggle "remote mode"; disables host bindings for
 	# using tmux in nested sessions
-	tmux bind -T root $toggle_key \
+	tmux bind -T root "$toggle_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_on.sh"
-	tmux bind -T off $toggle_key \
+	tmux bind -T off "$toggle_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_off.sh"
 
-	tmux bind -T root $on_key \
+	tmux bind -T root "$on_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_on.sh"
-	tmux bind -T off $on_key \
+	tmux bind -T off "$on_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_on.sh"
 
-	tmux bind -T root $off_key \
+	tmux bind -T root "$off_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_off.sh"
-	tmux bind -T off $off_key \
+	tmux bind -T off "$off_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_off.sh"
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,5 +1,5 @@
 option_not_set() {
   local option="$1"
-  local option_value=$(tmux show-option -gv $option)
+  local option_value=$(tmux show-option -gv "$option")
   [[ -z "$option_value" ]]
 }

--- a/tests/test_default_options.sh
+++ b/tests/test_default_options.sh
@@ -1,9 +1,9 @@
-  #/usr/bin/env bash
+  #!/usr/bin/env bash
 
   CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
   # bash helpers provided by 'tmux-test'
-  source $CURRENT_DIR/helpers/helpers.sh
+  source "$CURRENT_DIR/helpers/helpers.sh"
 
   # installs plugin from current repo in Vagrant (or on Travis)
   install_tmux_plugin_under_test_helper


### PR DESCRIPTION
## Summary
- Quote all variable expansions in `remote.tmux`, `helpers.sh`, and test script to prevent word splitting / glob expansion bugs
- Fix broken shebang in `test_default_options.sh` (`#/usr` → `#!/usr`)
- Fix README: `setw -g` → `set -g` for global options, add tmux 2.1+ requirement, update testing section
- Remove broken symlinks and `.gitignore` left over from the removed `tmux-test` submodule

## Test plan
- [ ] Verify GHA tests pass on this branch
- [ ] Install plugin via TPM and confirm keybindings still work
- [ ] Test F10/F11/F12 toggle behavior in a nested tmux session