### PR TITLE
Add configurable indicator text and colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![](https://i.imgur.com/3gfFGpk.png)
 
-Tested and working macOS and Linux.
+Tested and working on macOS and Linux. Requires tmux 2.1+.
 
 ## Installation
 
@@ -47,21 +47,32 @@ After installing the plugin, simply press <kbd>F12</kbd> to toggle remote-mode o
 
 ### Options
 
+#### Keybindings
+
 ```tmux
 # Change the default on keybinding (F10)
-setw -g @remote-on-key F10
+set -g @remote-on-key F10
 # Change the default off keybinding (F11)
-setw -g @remote-off-key F11
+set -g @remote-off-key F11
 # Change the default toggle keybinding (F12)
-setw -g @remote-toggle-key F12
+set -g @remote-toggle-key F12
+```
+
+#### Indicator
+
+When remote mode is active, a status-left indicator is shown. You can customize its text, foreground color, and background color:
+
+```tmux
+# Change the indicator text (default: " REMOTE >>>  ")
+set -g @remote-indicator-text " REMOTE >>>  "
+# Change the indicator foreground color (default: colour228)
+set -g @remote-indicator-fg "colour228"
+# Change the indicator background color (default: colour52)
+set -g @remote-indicator-bg "colour52"
 ```
 
 ## Testing
-Basic tests have been created with [tmux-test](https://github.com/tmux-plugins/tmux-test). To run tests:
-
-```
-> ./run_tests
-```
+Tests run automatically via [GitHub Actions](https://github.com/danyim/tmux-remote/actions/workflows/test.yml) on push and PR.
 
 ## Resources
 

--- a/remote.tmux
+++ b/remote.tmux
@@ -6,42 +6,51 @@ source "$CURRENT_DIR/scripts/variables.sh"
 source "$CURRENT_DIR/scripts/helpers.sh"
 
 main() {
-	if option_not_set $toggle_key_option; then
-		tmux set-option -g $toggle_key_option $default_toggle_key
+	if option_not_set "$toggle_key_option"; then
+		tmux set-option -g "$toggle_key_option" "$default_toggle_key"
 	fi
-	if option_not_set $on_key_option; then
-		tmux set-option -g $on_key_option $default_on_key
+	if option_not_set "$on_key_option"; then
+		tmux set-option -g "$on_key_option" "$default_on_key"
 	fi
-	if option_not_set $off_key_option; then
-		tmux set-option -g $off_key_option $default_off_key
+	if option_not_set "$off_key_option"; then
+		tmux set-option -g "$off_key_option" "$default_off_key"
+	fi
+	if option_not_set "$indicator_text_option"; then
+		tmux set-option -g "$indicator_text_option" "$default_indicator_text"
+	fi
+	if option_not_set "$indicator_fg_option"; then
+		tmux set-option -g "$indicator_fg_option" "$default_indicator_fg"
+	fi
+	if option_not_set "$indicator_bg_option"; then
+		tmux set-option -g "$indicator_bg_option" "$default_indicator_bg"
 	fi
 
 	local toggle_key=$(tmux show-option -gv "$toggle_key_option")
 	local on_key=$(tmux show-option -gv "$on_key_option")
 	local off_key=$(tmux show-option -gv "$off_key_option")
 
-	tmux unbind -T root $toggle_key
-	tmux unbind -T off $toggle_key
-	tmux unbind -T root $on_key
-	tmux unbind -T off $on_key
-	tmux unbind -T root $off_key
-	tmux unbind -T off $off_key
+	tmux unbind -T root "$toggle_key"
+	tmux unbind -T off "$toggle_key"
+	tmux unbind -T root "$on_key"
+	tmux unbind -T off "$on_key"
+	tmux unbind -T root "$off_key"
+	tmux unbind -T off "$off_key"
 
 	# Press the toggle key to toggle "remote mode"; disables host bindings for
 	# using tmux in nested sessions
-	tmux bind -T root $toggle_key \
+	tmux bind -T root "$toggle_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_on.sh"
-	tmux bind -T off $toggle_key \
+	tmux bind -T off "$toggle_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_off.sh"
 
-	tmux bind -T root $on_key \
+	tmux bind -T root "$on_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_on.sh"
-	tmux bind -T off $on_key \
+	tmux bind -T off "$on_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_on.sh"
 
-	tmux bind -T root $off_key \
+	tmux bind -T root "$off_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_off.sh"
-	tmux bind -T off $off_key \
+	tmux bind -T off "$off_key" \
 		run-shell "$CURRENT_DIR/scripts/toggle_off.sh"
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,5 +1,5 @@
 option_not_set() {
   local option="$1"
-  local option_value=$(tmux show-option -gv $option)
+  local option_value=$(tmux show-option -gv "$option")
   [[ -z "$option_value" ]]
 }

--- a/scripts/toggle_off.sh
+++ b/scripts/toggle_off.sh
@@ -2,5 +2,9 @@
 
 tmux set -u prefix
 tmux set -u key-table
-tmux set -g status-left ""
+
+# Restore the original status-left saved by toggle_on
+saved="$(tmux show-option -gv @remote-saved-status-left 2>/dev/null)"
+tmux set -g status-left "$saved"
+
 tmux refresh-client -S

--- a/scripts/toggle_on.sh
+++ b/scripts/toggle_on.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 
+# Save the current status-left so toggle_off can restore it
+tmux set -g @remote-saved-status-left "$(tmux show-option -gv status-left)"
+
+# Read indicator options
+text="$(tmux show-option -gv @remote-indicator-text)"
+fg="$(tmux show-option -gv @remote-indicator-fg)"
+bg="$(tmux show-option -gv @remote-indicator-bg)"
+
 tmux set prefix None
 tmux set key-table off
-tmux set -g status-left "#[fg=colour228,bg=colour52] REMOTE >>>  #[bg=default] "
+tmux set -g status-left "#[fg=$fg,bg=$bg]$text#[bg=default] "
 tmux if -F '#{pane_in_mode}' 'send-keys -X cancel'
 tmux refresh-client -S

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -2,8 +2,14 @@
 toggle_key_option="@remote-toggle-key"
 on_key_option="@remote-on-key"
 off_key_option="@remote-off-key"
+indicator_text_option="@remote-indicator-text"
+indicator_fg_option="@remote-indicator-fg"
+indicator_bg_option="@remote-indicator-bg"
 
 # default option values
 default_toggle_key="F12"
 default_on_key="F10"
 default_off_key="F11"
+default_indicator_text=" REMOTE >>>  "
+default_indicator_fg="colour228"
+default_indicator_bg="colour52"

--- a/tests/test_custom_indicator.sh
+++ b/tests/test_custom_indicator.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+  CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+  source "$CURRENT_DIR/helpers/helpers.sh"
+
+  # set custom indicator options before sourcing the plugin
+  set_tmux_conf_helper<<-HERE
+  set -g @remote-indicator-text " SSH "
+  set -g @remote-indicator-fg "colour255"
+  set -g @remote-indicator-bg "colour160"
+  run-shell '~/.tmux/plugins/tmux-plugin-under-test/*.tmux'
+HERE
+
+  _clone_the_plugin
+
+  tmux new -d
+
+  # verify custom options are preserved (not overwritten by defaults)
+  text="$(tmux show-option -gv @remote-indicator-text)"
+  fg="$(tmux show-option -gv @remote-indicator-fg)"
+  bg="$(tmux show-option -gv @remote-indicator-bg)"
+
+  if [ "$text" != " SSH " ]; then
+      fail_helper "Expected custom text ' SSH ', got '$text'"
+  fi
+  if [ "$fg" != "colour255" ]; then
+      fail_helper "Expected custom fg 'colour255', got '$fg'"
+  fi
+  if [ "$bg" != "colour160" ]; then
+      fail_helper "Expected custom bg 'colour160', got '$bg'"
+  fi
+
+  exit_helper

--- a/tests/test_indicator_defaults.sh
+++ b/tests/test_indicator_defaults.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+  CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+  source "$CURRENT_DIR/helpers/helpers.sh"
+
+  install_tmux_plugin_under_test_helper
+
+  tmux new -d
+
+  # get default indicator options
+  text="$(tmux show-option -gv @remote-indicator-text)"
+  fg="$(tmux show-option -gv @remote-indicator-fg)"
+  bg="$(tmux show-option -gv @remote-indicator-bg)"
+
+  if [ "$text" == "" ]; then
+      fail_helper "Default indicator text not set"
+  fi
+  if [ "$fg" == "" ]; then
+      fail_helper "Default indicator fg not set"
+  fi
+  if [ "$bg" == "" ]; then
+      fail_helper "Default indicator bg not set"
+  fi
+
+  # verify expected defaults
+  if [ "$text" != " REMOTE >>>  " ]; then
+      fail_helper "Expected default text ' REMOTE >>>  ', got '$text'"
+  fi
+  if [ "$fg" != "colour228" ]; then
+      fail_helper "Expected default fg 'colour228', got '$fg'"
+  fi
+  if [ "$bg" != "colour52" ]; then
+      fail_helper "Expected default bg 'colour52', got '$bg'"
+  fi
+
+  exit_helper

--- a/tests/test_status_left_restore.sh
+++ b/tests/test_status_left_restore.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+  CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+  source "$CURRENT_DIR/helpers/helpers.sh"
+
+  # set a custom status-left before sourcing the plugin
+  set_tmux_conf_helper<<-HERE
+  set -g status-left " #S "
+  run-shell '~/.tmux/plugins/tmux-plugin-under-test/*.tmux'
+HERE
+
+  _clone_the_plugin
+
+  tmux new -d
+
+  original="$(tmux show-option -gv status-left)"
+
+  # simulate toggle on
+  bash ~/.tmux/plugins/tmux-plugin-under-test/scripts/toggle_on.sh
+
+  toggled="$(tmux show-option -gv status-left)"
+  if [ "$toggled" == "$original" ]; then
+      fail_helper "status-left should change after toggle on"
+  fi
+
+  # simulate toggle off
+  bash ~/.tmux/plugins/tmux-plugin-under-test/scripts/toggle_off.sh
+
+  restored="$(tmux show-option -gv status-left)"
+  if [ "$restored" != "$original" ]; then
+      fail_helper "Expected status-left to be restored to '$original', got '$restored'"
+  fi
+
+  exit_helper


### PR DESCRIPTION
## Summary
- Add three new tmux options for customizing the remote mode indicator:
  - `@remote-indicator-text` — the status-left text (default: ` REMOTE >>>  `)
  - `@remote-indicator-fg` — foreground color (default: `colour228`)
  - `@remote-indicator-bg` — background color (default: `colour52`)
- Save/restore original `status-left` on toggle to avoid wiping theme customizations (fixes #1)
- Fix unquoted variable expansions throughout
- Update README with new options, correct `setw` → `set` syntax, add tmux 2.1+ requirement

## Test plan
- [ ] Verify default behavior is unchanged (no options set → same yellow-on-red indicator)
- [ ] Set custom options and verify they take effect on toggle
- [ ] Toggle off and verify original status-left is restored