### PR TITLE
fix for saving and disabling REMOTE>>> after disconnect

### DIFF
--- a/scripts/toggle_on.sh
+++ b/scripts/toggle_on.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-# Save the current status-left so toggle_off can restore it
-tmux set -g @remote-saved-status-left "$(tmux show-option -gv status-left)"
+# Save the current status-left so toggle_off can restore it (only once)
+saved="$(tmux show-option -gv @remote-saved-status-left)"
+if [[ -z "$saved" ]]; then
+    tmux set -g @remote-saved-status-left "$(tmux show-option -gv status-left)"
+fi
 
 # Read indicator options
 text="$(tmux show-option -gv @remote-indicator-text)"


### PR DESCRIPTION
I'm using this tmux plugin but sometimes after it gets disconnected status bar stays in REMOTE >>> mode and none of the F10,F11,F12 keys can change it back to OFF

The issue is in `toggle_off.sh`:
```
saved="$(tmux show-option -gv @remote-saved-status-left 2>/dev/null)"
tmux set -g status-left "$saved"
```

If `@remote-saved-status-left` wasn't saved properly (or was overwritten), the restore fails silently. 
Also, `toggle_on.sh` saves `status-left` every time it runs, so if you press F10 again while already in remote mode, it saves the already-modified status bar as the "original" — then `toggle_off.sh` "restores" to the wrong value.

I think this fix should resolve it. So far I did not have any cases where I would stuck in REMOTE>>> state